### PR TITLE
Add SILE document format

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ nix run
 - [HTML](./html/)
 - [JSON](./js/)
 - [Open Office](./ODT/)
+- [sile](./sile/)
 - [SVG](./svg/)
 - [tex](./tex/)
 - [tree](./tree/)

--- a/sile/hayalet-sevgilim.sil
+++ b/sile/hayalet-sevgilim.sil
@@ -1,0 +1,71 @@
+\begin{document}
+\language[main=tr]
+\set[parameter=document.parskip,value=1ex]
+
+\begin{center}
+\font[size=4em]{Hayalet Sevgilim}
+
+\font[size=2em,style=Italic]{İrem Aydın — 15 Şubat 2006}
+\end{center}
+\bigskip
+
+\begin[right=true]{ragged}
+Ceza mı bu\break
+Çektiğim çile mi\break
+Yıllardır tuttuğum nöbet bitmeyecek mi?\break
+Bir küçük kar tanesi gibiyim\break
+Avucunda eriyen dön bebeğim
+
+Gözyaşlarını görürsem\break
+Erir kanatlarım\break
+Uçamam rüyalarında yanına\break
+Sonsuzluk senle başladı\break
+O küçük dünyamda\break
+Unutma gittiğinde yarım kaldım
+
+Çöllerdeyim yanıyorum\break
+Kutuptayım üşüyorum\break
+Ceza benim çekiyorum ne olur dön\break
+Uzanıyorum tutamıyorum\break
+Özlüyorum ağlıyorum\break
+Yasak mısın anlamıyorum ne olur dön
+
+Sevmesen de beni özledim sesini\break
+Git desem de yine gitmesen\break
+Yıllardır çektiğim bu hasret mi çile mi?\break
+Haram mısın bana bi’ bilsem
+
+Sevmesen de beni özledim sesini\break
+Git desem de yine gitmesen\break
+Yıllardır çektiğim bu hasret mi çile mi?\break
+Haram mısın bana bi’ bilsem
+
+Bebeğim benim, hayalet sevgilim\break
+Bebeğim benim, hayalet sevgilim
+
+Hayalet sevgilim
+
+Çöllerdeyim yanıyorum\break
+Kutuptayım üşüyorum\break
+Ceza benim çekiyorum ne olur dön\break
+Uzanıyorum tutamıyorum\break
+Özlüyorum ağlıyorum\break
+Yasak mısın anlamıyorum ne olur dön
+
+Sevmesen de beni özledim sesini\break
+Git desem de yine gitmesen\break
+Yıllardır çektiğim bu hasret mi çile mi?\break
+Haram mısın bana bi’ bilsem
+
+Sevmesen de beni özledim sesini\break
+Git desem de yine gitmesen\break
+Yıllardır çektiğim bu hasret mi çile mi?\break
+Haram mısın bana bi’ bilsem
+
+Bebeğim benim hayalet sevgilim\break
+Bebeğim benim hayalet sevgilim
+
+Hayalet sevgilim\break
+Hayalet sevgilim
+\end{ragged}
+\end{document}


### PR DESCRIPTION
SILE is a typesetting engine similar in concept to TeX but written from scratch a couple decades more recently.

This can be typeset to a PDF with:

```console
$ sile sile/heyalet-sevgilim.sil
```

Packages and easy installation exists for many systems, but for testing without installing SILE you can also use Docker or Nix:

```console
# via Docker
$ docker run --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/sile:latest sile/hayalet-sevgilim.sil

# via Nix
$ nix shell -f '<nixpkgs>' -i sile -c sile sile/hayalet-sevgilim.sil
```

I took a middle road between some of the other formats that either took minimalist approaches (e.g. ODT that has just the bare text of the poem with no formatting) and maximalist (e.g. TeX that has a title, author, date, section heading, two columns, etc.).

I am happy to amend this in either direction if preferred. I could simplify it to be as bare as possible or spend a little more time on it and make it a lot prettier.
