### PR TITLE
Overhaul TEX example

### DIFF
--- a/tex/hayalet-sevgilim.tex
+++ b/tex/hayalet-sevgilim.tex
@@ -1,71 +1,72 @@
-\documentclass{proc}
-\usepackage{graphicx}
+\documentclass[twocolumn]{article}
+
+\setlength{\parindent}{0cm}
+\setlength{\parskip}{3ex}
+
+\title{Hayalet Sevgilim}
+\author{\.{I}rem Ayd{\i}n}
+\date{15-\c{S}ubat-2006}
 
 \begin{document}
 
-\title{Hayalet Sevgilim \LaTeX{}}
-\author{\.{I}rem Aydin 15-\c{S}ubat-2006}
-
 \maketitle
-
-\section{Hayalet Sevgilim}
 
 Ceza m{\i} bu\\
 \c{C}ekti\u{g}im \c{c}ile mi\\
 Y{\i}llard{\i}r tuttu\u{g}um n\"{o}bet bitmeyecek mi?\\
 Bir k\"{u}\c{c}\"{u}k kar tanesi gibiyim\\
-Avucunda eriyen d\"{o}n bebe\u{g}im\\
-\\
+Avucunda eriyen d\"{o}n bebe\u{g}im
+
 G\"{o}zyaşlar{\i}n{\i} g\"{o}r\"{u}rsem\\
 Erir kanatlar{\i}m\\
 U\c{c}amam r\"{u}yalar{\i}nda yan{\i}na\\
 Sonsuzluk senle başlad{\i}\\
 O k\"{u}\c{c}\"{u}k d\"{u}nyamda\\
-Unutma gitti\u{g}inde yar{\i}m kald{\i}m\\
-\\
+Unutma gitti\u{g}inde yar{\i}m kald{\i}m
+
 \c{C}\"{o}llerdeyim yan{\i}yorum\\
 Kutuptay{\i}m \"{u}ş\"{u}yorum\\
 Ceza benim \c{c}ekiyorum ne olur d\"{o}n\\
 Uzan{\i}yorum tutam{\i}yorum\\
 \"{O}zl\"{u}yorum a\u{g}l{\i}yorum\\
-Yasak m{\i}s{\i}n anlam{\i}yorum ne olur d\"{o}n\\
-\\
+Yasak m{\i}s{\i}n anlam{\i}yorum ne olur d\"{o}n
+
 Sevmesen de beni \"{o}zledim sesini\\
 Git desem de yine gitmesen\\
 Y{\i}llard{\i}r \c{c}ekti\u{g}im bu hasret mi \c{c}ile mi?\\
-Haram m{\i}s{\i}n bana bi' bilsem\\
-\\
+Haram m{\i}s{\i}n bana bi' bilsem
+
 Sevmesen de beni \"{o}zledim sesini\\
 Git desem de yine gitmesen\\
 Y{\i}llard{\i}r \c{c}ekti\u{g}im bu hasret mi \c{c}ile mi?\\
-Haram m{\i}s{\i}n bana bi' bilsem\\
-\\
+Haram m{\i}s{\i}n bana bi' bilsem
+
 Bebe\u{g}im benim, hayalet sevgilim\\
-Bebe\u{g}im benim, hayalet sevgilim\\
-\\
-Hayalet sevgilim\\
-\\
+Bebe\u{g}im benim, hayalet sevgilim
+
+Hayalet sevgilim
+
 \c{C}\"{o}llerdeyim yan{\i}yorum\\
 Kutuptay{\i}m \"{u}ş\"{u}yorum\\
 Ceza benim \c{c}ekiyorum ne olur d\"{o}n\\
 Uzan{\i}yorum tutam{\i}yorum\\
 \"{O}zl\"{u}yorum a\u{g}l{\i}yorum\\
-Yasak m{\i}s{\i}n anlam{\i}yorum ne olur d\"{o}n\\
-\\
+Yasak m{\i}s{\i}n anlam{\i}yorum ne olur d\"{o}n
+
 Sevmesen de beni \"{o}zledim sesini\\
 Git desem de yine gitmesen\\
 Y{\i}llard{\i}r \c{c}ekti\u{g}im bu hasret mi \c{c}ile mi?\\
-Haram m{\i}s{\i}n bana bi' bilsem\\
-\\
+Haram m{\i}s{\i}n bana bi' bilsem
+
 Sevmesen de beni \"{o}zledim sesini\\
 Git desem de yine gitmesen\\
 Y{\i}llard{\i}r \c{c}ekti\u{g}im bu hasret mi \c{c}ile mi?\\
-Haram m{\i}s{\i}n bana bi' bilsem\\
-\\
+Haram m{\i}s{\i}n bana bi' bilsem
+
 Bebe\u{g}im benim hayalet sevgilim\\
-Bebe\u{g}im benim hayalet sevgilim\\
-\\
+Bebe\u{g}im benim hayalet sevgilim
+
 Hayalet sevgilim\\
-Hayalet sevgilim\\
+Hayalet sevgilim
 
 \end{document}


### PR DESCRIPTION
* Use much more generic article class rather than proc (procedings)
  class that has unfortunate side effects such as adding an English
  "Page" to the footer.

* Fix author name using Turkish undotted-i.

* Drop useless package import of graphicx, the only effect of which was
  changing the default paper size to letter instead of A4 and messing
  with margins. A4 is fine and if we are showing off document formats
  sticking closer to defaults seems to be better.

* Remove date from author meta data field, put it in date meta data
  field.

* Drop the section header, duplicated with the title on the same page.
  If exemplifying the format is desired at least `\section*{}` would
  have been better to suppress the outline numbering, which does not
  serve this document.

* Use paragraph formatting. Eschewing paragraphs in favor of line breaks
  was probably done to avoid paragraph indents, but it is not idiomatic
  of the document format and has unfortunate side effects such as
  breaking a single stanza of the poem up into two columns because the
  whole poem was considered one blob. By using paragraph breaks the TeX
  engine knows how to do this better. Indentation is suppressed the usual
  way.

* Remove the `\latex` format identifier from the title. At the very
  least it is misinformed: this document is not written in LaTeX input
  style: if it was it would be fine to use UTF-8 input and normal
  Turkish encodings. Only the pure original "TeX" format would require
  the archaic input of all the Turkish letters using ASCII with
  diacritic modifiers.
