### PR TITLE
Ensuring no innerHTML is called for <br> tag

### DIFF
--- a/html/index-scripted.html
+++ b/html/index-scripted.html
@@ -78,11 +78,13 @@
 
       for (let i = 0; i < data.length; i++) {
         const soz = data[i];
-        let el = document.createElement("p");
-        if (soz === "") {
+        let el;
+        if(soz.length > 0) {
+          el = document.createElement("p");
+          el.innerHTML = soz;
+        } else {
           el = document.createElement("br");
         }
-        el.innerHTML = soz;
         container.appendChild(el);
       }
     </script>


### PR DESCRIPTION
If the lyrics line is an empty line, the `<br>` element was added to the HTML, however, `innerHTML` was called to `<br>` element as well. This PR ensures no `innerHTML` is called if the current line of the lyrics is blank.